### PR TITLE
 <fix>: <Back puppeteer error>

### DIFF
--- a/back/drawCrawl.js
+++ b/back/drawCrawl.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 
 export default async function drawCrawl() {
   const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
     headless: true,
   });
 

--- a/back/drawPages.js
+++ b/back/drawPages.js
@@ -5,6 +5,7 @@ export default async function drawPages(id) {
   const selectLink = drawLoadData[id].link;
 
   const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
     headless: true,
   });
 


### PR DESCRIPTION
 ec2 인스턴스가 리눅스라서 그런가 자잘하게 오류가 많다.
 이 부분 말고도 해결할 에러가 너무 많다.
 Ubuntu 18.04 Headless Chrome Node API
 - Puppeteer - Installation Guide #3443
 깃헙에 올라와 있는대로 리눅스 환경에 종속성을 추가하고
 args를 넣어줬다.