### PR TITLE
 <fix>: <Front API 주소 교체>

### DIFF
--- a/front/src/api/draws.ts
+++ b/front/src/api/draws.ts
@@ -1,12 +1,16 @@
 import axios from 'axios';
 
 export async function getDrawsList() {
-  const response = await axios.get<DrawsList>('http://localhost:4000');
+  const response = await axios.get<DrawsList>(
+    'http://ec2-3-34-140-151.ap-northeast-2.compute.amazonaws.com:4000/'
+  );
   return response.data;
 }
 
 export async function getDrawsData(i: number) {
-  const response = await axios.get<DrawsData>(`http://localhost:4000/${i}`);
+  const response = await axios.get<DrawsData>(
+    `http://ec2-3-34-140-151.ap-northeast-2.compute.amazonaws.com:4000/${i}`
+  );
   return response.data;
 }
 


### PR DESCRIPTION
 EC2 인스턴스 설정이 드디어 오류없이 제대로 진행된다.
 API 주소를 localhost에서 벗어났다. 시간이 된다면 도메인도 진행해보고 싶다.